### PR TITLE
Improve chat input contrast

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -547,7 +547,7 @@ export default function ChatInterface({ agentId, conversationId }: ChatInterface
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder={`Escribe tu consulta para ${agent.name}...`}
-                className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 placeholder:text-gray-600"
                 disabled={isLoading}
               />
               <button


### PR DESCRIPTION
## Summary
- update `ChatInterface` input styles for better text and placeholder contrast

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c823380748321a26da79e89140897