### PR TITLE
Redesign admin panel UI

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,12 +1,27 @@
-// app/admin/page.tsx - Versión con estilos forzados
 'use client'
 import { useState, useEffect } from 'react'
+
+type Section = 'dashboard' | 'users' | 'conversations' | 'agents' | 'settings'
 
 export default function AdminPage() {
   const [stats, setStats] = useState({ total: 0 })
   const [password, setPassword] = useState('')
   const [authorized, setAuthorized] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [active, setActive] = useState<Section>('dashboard')
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768)
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  useEffect(() => {
+    setSidebarOpen(!isMobile)
+  }, [isMobile])
 
   useEffect(() => {
     if (authorized) {
@@ -17,10 +32,8 @@ export default function AdminPage() {
   const loadStats = async () => {
     setLoading(true)
     try {
-      console.log('📊 Loading stats...')
       const response = await fetch('/api/admin/stats')
       const data = await response.json()
-      console.log('📊 Stats loaded:', data)
       setStats(data)
     } catch (error) {
       console.error('Error loading stats:', error)
@@ -51,6 +64,35 @@ export default function AdminPage() {
     }
   }
 
+  const navItems: { id: Section; label: string; icon: string }[] = [
+    { id: 'dashboard', label: 'Dashboard', icon: '📊' },
+    { id: 'users', label: 'Usuarios', icon: '👥' },
+    { id: 'conversations', label: 'Conversaciones', icon: '💬' },
+    { id: 'agents', label: 'Agentes', icon: '🤖' },
+    { id: 'settings', label: 'Configuración', icon: '⚙️' },
+  ]
+
+  const cardStyle = {
+    backgroundColor: '#ffffff',
+    padding: '20px',
+    borderRadius: '8px',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+    flex: '1 1 200px',
+    minWidth: '200px',
+  }
+
+  const linkBase = {
+    padding: '10px 15px',
+    margin: '5px 0',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap' as const,
+  }
+
+  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
+
   if (!authorized) {
     return (
       <div style={{
@@ -63,13 +105,13 @@ export default function AdminPage() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 9999
+        zIndex: 9999,
       }}>
         <div style={{
           padding: '40px',
           border: '2px solid #000',
           backgroundColor: '#f0f0f0',
-          textAlign: 'center'
+          textAlign: 'center',
         }}>
           <h1 style={{ color: '#000', fontSize: '24px', margin: '0 0 20px 0' }}>
             🔒 ADMIN INNOTECH
@@ -84,7 +126,7 @@ export default function AdminPage() {
               fontSize: '16px',
               border: '2px solid #000',
               marginBottom: '20px',
-              width: '200px'
+              width: '200px',
             }}
           />
           <br />
@@ -103,7 +145,7 @@ export default function AdminPage() {
               backgroundColor: '#007acc',
               color: 'white',
               border: 'none',
-              cursor: 'pointer'
+              cursor: 'pointer',
             }}
           >
             ENTRAR
@@ -113,89 +155,173 @@ export default function AdminPage() {
     )
   }
 
-  return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      backgroundColor: 'white',
-      padding: '20px',
-      overflow: 'auto',
-      zIndex: 9999
-    }}>
-      <h1 style={{ color: '#000', fontSize: '32px', margin: '0 0 30px 0' }}>
-        🔧 ADMIN INNOTECH
-      </h1>
+  const showSidebar = !isMobile || sidebarOpen
 
-      <div style={{
-        border: '3px solid #000',
-        padding: '30px',
-        marginBottom: '30px',
-        backgroundColor: '#f9f9f9'
-      }}>
-        <h2 style={{ color: '#000', fontSize: '24px', margin: '0 0 20px 0' }}>
-          📊 ESTADÍSTICAS
-        </h2>
-        <p style={{ color: '#000', fontSize: '32px', fontWeight: 'bold', margin: '20px 0' }}>
-          {loading ? '⏳ CARGANDO...' : `💬 CONVERSACIONES: ${stats.total}`}
-        </p>
-        <button
-          onClick={loadStats}
-          disabled={loading}
+  return (
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', backgroundColor: '#e5e7eb' }}>
+      {showSidebar && (
+        <aside
+          style={{
+            width: '220px',
+            backgroundColor: '#0f172a',
+            color: 'white',
+            padding: '20px 10px',
+            display: 'flex',
+            flexDirection: 'column',
+            position: isMobile ? 'fixed' : 'relative',
+            height: '100%',
+            zIndex: 1000,
+          }}
+        >
+          <div style={{ fontWeight: 'bold', fontSize: '18px', marginBottom: '20px', paddingLeft: '5px' }}>
+            🔧 Admin
+          </div>
+          <nav style={{ flex: 1 }}>
+            {navItems.map((item) => (
+              <div
+                key={item.id}
+                onClick={() => {
+                  setActive(item.id)
+                  if (isMobile) setSidebarOpen(false)
+                }}
+                style={{
+                  ...linkBase,
+                  backgroundColor: active === item.id ? '#1e40af' : 'transparent',
+                }}
+              >
+                <span style={{ marginRight: '10px' }}>{item.icon}</span>
+                {item.label}
+              </div>
+            ))}
+          </nav>
+          <a
+            href="/"
+            style={{ ...linkBase, marginTop: 'auto', color: 'white', textDecoration: 'none' }}
+          >
+            ← Volver al sitio
+          </a>
+        </aside>
+      )}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <header
           style={{
             padding: '10px 20px',
-            fontSize: '16px',
-            backgroundColor: '#666',
-            color: 'white',
-            border: 'none',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            marginRight: '20px'
+            backgroundColor: '#ffffff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
           }}
         >
-          🔄 ACTUALIZAR
-        </button>
-      </div>
+          {isMobile && (
+            <button
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              style={{
+                fontSize: '20px',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                marginRight: '10px',
+              }}
+            >
+              ☰
+            </button>
+          )}
+          <div style={{ color: '#6b7280', fontSize: '14px' }}>
+            {active === 'dashboard' ? 'Dashboard' : `Dashboard / ${capitalize(active)}`}
+          </div>
+          <div>👤 Admin</div>
+        </header>
+        <main style={{ flex: 1, overflow: 'auto', padding: '20px' }}>
+          {active === 'dashboard' && (
+            <div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '20px', marginBottom: '20px' }}>
+                <div style={cardStyle as React.CSSProperties}>
+                  <h3 style={{ marginBottom: '10px' }}>👥 Usuarios</h3>
+                  <p>Próximamente</p>
+                </div>
+                <div style={cardStyle as React.CSSProperties}>
+                  <h3 style={{ marginBottom: '10px' }}>💬 Conversaciones</h3>
+                  <p style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '10px' }}>
+                    {loading ? 'Cargando...' : stats.total}
+                  </p>
+                  <button
+                    onClick={loadStats}
+                    disabled={loading}
+                    style={{
+                      padding: '6px 12px',
+                      backgroundColor: '#007acc',
+                      color: 'white',
+                      border: 'none',
+                      cursor: loading ? 'not-allowed' : 'pointer',
+                      borderRadius: '4px',
+                      fontSize: '14px',
+                    }}
+                  >
+                    🔄 Actualizar
+                  </button>
+                </div>
+                <div style={cardStyle as React.CSSProperties}>
+                  <h3 style={{ marginBottom: '10px' }}>🤖 Uso por Agente</h3>
+                  <p>Próximamente</p>
+                </div>
+              </div>
+              <div
+                style={{
+                  ...cardStyle,
+                  height: '200px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                } as React.CSSProperties}
+              >
+                📈 Gráfico próximamente
+              </div>
+              <div
+                style={{
+                  marginTop: '20px',
+                  border: '1px solid #cc0000',
+                  backgroundColor: '#fff0f0',
+                  padding: '20px',
+                  borderRadius: '8px',
+                }}
+              >
+                <h3 style={{ color: '#cc0000', marginBottom: '10px' }}>🗑️ Zona Peligrosa</h3>
+                <button
+                  onClick={deleteAll}
+                  disabled={loading || stats.total === 0}
+                  style={{
+                    padding: '10px 20px',
+                    backgroundColor: stats.total === 0 ? '#ccc' : '#cc0000',
+                    color: 'white',
+                    border: 'none',
+                    cursor: loading || stats.total === 0 ? 'not-allowed' : 'pointer',
+                    fontWeight: 'bold',
+                    borderRadius: '4px',
+                  }}
+                >
+                  {loading ? '⏳ Eliminando...' : `🚨 Eliminar Todo (${stats.total})`}
+                </button>
+              </div>
+            </div>
+          )}
 
-      <div style={{
-        border: '3px solid #cc0000',
-        padding: '30px',
-        marginBottom: '30px',
-        backgroundColor: '#fff0f0'
-      }}>
-        <h2 style={{ color: '#cc0000', fontSize: '24px', margin: '0 0 20px 0' }}>
-          🗑️ ZONA PELIGROSA
-        </h2>
-        <button
-          onClick={deleteAll}
-          disabled={loading || stats.total === 0}
-          style={{
-            padding: '20px 40px',
-            fontSize: '20px',
-            backgroundColor: stats.total === 0 ? '#ccc' : '#cc0000',
-            color: 'white',
-            border: 'none',
-            cursor: (loading || stats.total === 0) ? 'not-allowed' : 'pointer',
-            fontWeight: 'bold'
-          }}
-        >
-          {loading ? '⏳ ELIMINANDO...' : `🚨 ELIMINAR TODO (${stats.total})`}
-        </button>
+          {active !== 'dashboard' && (
+            <div
+              style={{
+                backgroundColor: '#ffffff',
+                padding: '40px',
+                borderRadius: '8px',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                textAlign: 'center',
+              }}
+            >
+              <h2 style={{ fontSize: '24px', marginBottom: '10px' }}>{capitalize(active)}</h2>
+              <p>Próximamente</p>
+            </div>
+          )}
+        </main>
       </div>
-
-      <a
-        href="/"
-        style={{
-          color: '#007acc',
-          fontSize: '18px',
-          textDecoration: 'underline',
-          display: 'block',
-          marginTop: '20px'
-        }}
-      >
-        ← VOLVER AL SITIO
-      </a>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- modern admin dashboard with sidebar navigation and header
- dashboard cards show conversation stats and keep delete functionality
- other sections display placeholder content
- sidebar collapsible on small screens

## Testing
- `npx next lint` *(fails: no-html-link-for-pages and unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c88cb43dc8321b4fa5363bd1de09b