### PR TITLE
Fix admin input contrast

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -89,7 +89,7 @@ export default function AdminPage() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="admin123"
+              placeholder="Contraseña de administrador"
               style={{
                 padding: '10px',
                 fontSize: '16px',
@@ -97,6 +97,7 @@ export default function AdminPage() {
                 marginBottom: '20px',
                 width: '200px'
               }}
+              className="text-gray-900 placeholder:text-gray-600"
             />
             <br />
             <button


### PR DESCRIPTION
## Summary
- improve admin password input placeholder and text contrast

## Testing
- `npm run lint` *(fails: Do not use an `<a>` element to navigate to `/`. Use `<Link />` ... etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c911d3a3c8321b03db9f3b21acf08